### PR TITLE
feat: add credentials: 'include' to admin API fetch calls

### DIFF
--- a/lib/__tests__/api.test.js
+++ b/lib/__tests__/api.test.js
@@ -72,7 +72,8 @@ describe('useAPI Hook', () => {
       })
 
       expect(fetch).toHaveBeenCalledWith(
-        'http://localhost:3000/api/orders?userId=user123'
+        'http://localhost:3000/api/orders?userId=user123',
+        { credentials: 'include' }
       )
       expect(orders).toEqual(mockOrders)
     })
@@ -167,7 +168,8 @@ describe('useAPI Hook', () => {
 
       // The URL should properly encode special characters
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('userId=user')
+        expect.stringContaining('userId=user'),
+        { credentials: 'include' }
       )
     })
   })
@@ -275,7 +277,7 @@ describe('useAPI Hook', () => {
         settings = await result.current.getPhotoImageSettings('photo123')
       })
 
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/photos/photo123/image-settings')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/photos/photo123/image-settings', { credentials: 'include' })
       expect(settings).toEqual(mockSettings)
     })
 
@@ -374,7 +376,8 @@ describe('useAPI Hook', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/photos/photo123/image-settings', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ brightness: 15, contrast: 10 })
+        body: JSON.stringify({ brightness: 15, contrast: 10 }),
+        credentials: 'include'
       })
       expect(settings).toEqual(mockUpdatedSettings)
     })
@@ -495,7 +498,7 @@ describe('Standalone per-photo API exports', () => {
       })
 
       const result = await getPhotoImageSettings('photo123')
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/photos/photo123/image-settings')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/photos/photo123/image-settings', { credentials: 'include' })
       expect(result).toEqual({ brightness: 10, quality: 85 })
     })
 
@@ -534,7 +537,8 @@ describe('Standalone per-photo API exports', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/photos/photo123/image-settings', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ brightness: 15 })
+        body: JSON.stringify({ brightness: 15 }),
+        credentials: 'include'
       })
       expect(result).toEqual({ brightness: 15, quality: 90 })
     })

--- a/lib/__tests__/contentApi.test.js
+++ b/lib/__tests__/contentApi.test.js
@@ -37,7 +37,7 @@ describe('useContentAPI Hook', () => {
         pages = await result.current.getAllPages()
       })
 
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages', { credentials: 'include' })
       expect(pages).toEqual(mockPages)
     })
 
@@ -115,7 +115,7 @@ describe('useContentAPI Hook', () => {
         page = await result.current.getPageContent('page1')
       })
 
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages/page1')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages/page1', { credentials: 'include' })
       expect(page).toEqual(mockPage)
     })
 
@@ -196,7 +196,8 @@ describe('useContentAPI Hook', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages/page1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ hero: 'Updated' })
+        body: JSON.stringify({ hero: 'Updated' }),
+        credentials: 'include'
       })
       expect(updated).toEqual(mockUpdatedPage)
     })
@@ -277,7 +278,7 @@ describe('useContentAPI Hook', () => {
         settings = await result.current.getImageSettings()
       })
 
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/images')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/images', { credentials: 'include' })
       expect(settings).toEqual(mockSettings)
     })
 
@@ -358,7 +359,8 @@ describe('useContentAPI Hook', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/images', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ maxWidth: 2048, quality: 90 })
+        body: JSON.stringify({ maxWidth: 2048, quality: 90 }),
+        credentials: 'include'
       })
       expect(settings).toEqual(mockUpdatedSettings)
     })
@@ -439,7 +441,7 @@ describe('useContentAPI Hook', () => {
         settings = await result.current.getLayoutSettings()
       })
 
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/layout')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/layout', { credentials: 'include' })
       expect(settings).toEqual(mockLayout)
     })
 
@@ -520,7 +522,8 @@ describe('useContentAPI Hook', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/layout', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ columns: 4, spacing: 'wide' })
+        body: JSON.stringify({ columns: 4, spacing: 'wide' }),
+        credentials: 'include'
       })
       expect(settings).toEqual(mockUpdatedLayout)
     })
@@ -658,7 +661,7 @@ describe('Standalone contentApi exports', () => {
       })
 
       const result = await getAllPages()
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages', { credentials: 'include' })
       expect(result).toEqual([{ _id: '1', title: 'Home' }])
     })
 
@@ -688,7 +691,7 @@ describe('Standalone contentApi exports', () => {
       })
 
       const result = await getPageContent('1')
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages/1')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages/1', { credentials: 'include' })
       expect(result).toEqual({ _id: '1', title: 'Home' })
     })
 
@@ -712,7 +715,8 @@ describe('Standalone contentApi exports', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/pages/1', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: 'Updated' })
+        body: JSON.stringify({ title: 'Updated' }),
+        credentials: 'include'
       })
       expect(result).toEqual({ _id: '1', title: 'Updated' })
     })
@@ -734,7 +738,7 @@ describe('Standalone contentApi exports', () => {
       })
 
       const result = await getImageSettings()
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/images')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/images', { credentials: 'include' })
       expect(result).toEqual({ quality: 85 })
     })
 
@@ -758,7 +762,8 @@ describe('Standalone contentApi exports', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/images', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ quality: 90 })
+        body: JSON.stringify({ quality: 90 }),
+        credentials: 'include'
       })
       expect(result).toEqual({ quality: 90 })
     })
@@ -780,7 +785,7 @@ describe('Standalone contentApi exports', () => {
       })
 
       const result = await getLayoutSettings()
-      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/layout')
+      expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/layout', { credentials: 'include' })
       expect(result).toEqual({ columns: 3 })
     })
 
@@ -804,7 +809,8 @@ describe('Standalone contentApi exports', () => {
       expect(fetch).toHaveBeenCalledWith('http://localhost:3000/api/admin/settings/layout', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ columns: 4 })
+        body: JSON.stringify({ columns: 4 }),
+        credentials: 'include'
       })
       expect(result).toEqual({ columns: 4 })
     })

--- a/lib/api.js
+++ b/lib/api.js
@@ -167,7 +167,7 @@ const useAPI = () => {
         throw new Error('API base URL is not defined')
       }
 
-      const res = await fetch(`${base}/api/orders?userId=${encodeURIComponent(userId)}`)
+      const res = await fetch(`${base}/api/orders?userId=${encodeURIComponent(userId)}`, { credentials: 'include' })
 
       if (!res.ok) {
         throw new Error(`Failed to fetch orders: ${res.status} ${res.statusText}`)
@@ -211,7 +211,7 @@ const useAPI = () => {
       const base = process.env.NEXT_PUBLIC_API_BASE
       if (!base) throw new Error('API base URL is not defined')
 
-      const res = await fetch(`${base}/api/admin/photos/${encodeURIComponent(photoId)}/image-settings`)
+      const res = await fetch(`${base}/api/admin/photos/${encodeURIComponent(photoId)}/image-settings`, { credentials: 'include' })
 
       if (!res.ok) {
         throw new Error(`Failed to fetch photo image settings: ${res.status} ${res.statusText}`)
@@ -234,7 +234,8 @@ const useAPI = () => {
       const res = await fetch(`${base}/api/admin/photos/${encodeURIComponent(photoId)}/image-settings`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settings)
+        body: JSON.stringify(settings),
+        credentials: 'include'
       })
 
       if (!res.ok) {
@@ -401,7 +402,7 @@ export async function getPhotoImageSettings(photoId) {
   const base = process.env.NEXT_PUBLIC_API_BASE
   if (!base) throw new Error('API base URL is not defined')
 
-  const res = await fetch(`${base}/api/admin/photos/${encodeURIComponent(photoId)}/image-settings`)
+  const res = await fetch(`${base}/api/admin/photos/${encodeURIComponent(photoId)}/image-settings`, { credentials: 'include' })
 
   if (!res.ok) {
     throw new Error(`Failed to fetch photo image settings: ${res.status} ${res.statusText}`)
@@ -419,7 +420,8 @@ export async function updatePhotoImageSettings(photoId, settings) {
   const res = await fetch(`${base}/api/admin/photos/${encodeURIComponent(photoId)}/image-settings`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(settings)
+    body: JSON.stringify(settings),
+    credentials: 'include'
   })
 
   if (!res.ok) {

--- a/lib/contentApi.js
+++ b/lib/contentApi.js
@@ -10,7 +10,7 @@ const useContentAPI = () => {
       const base = process.env.NEXT_PUBLIC_API_BASE
       if (!base) throw new Error('API base URL is not defined')
 
-      const res = await fetch(`${base}/api/admin/pages`)
+      const res = await fetch(`${base}/api/admin/pages`, { credentials: 'include' })
       if (!res.ok) throw new Error(`Failed to fetch pages: ${res.status} ${res.statusText}`)
 
       return await res.json()
@@ -27,7 +27,7 @@ const useContentAPI = () => {
       const base = process.env.NEXT_PUBLIC_API_BASE
       if (!base) throw new Error('API base URL is not defined')
 
-      const res = await fetch(`${base}/api/admin/pages/${pageId}`)
+      const res = await fetch(`${base}/api/admin/pages/${pageId}`, { credentials: 'include' })
       if (!res.ok) throw new Error(`Failed to fetch page content: ${res.status} ${res.statusText}`)
 
       return await res.json()
@@ -47,7 +47,8 @@ const useContentAPI = () => {
       const res = await fetch(`${base}/api/admin/pages/${pageId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(content)
+        body: JSON.stringify(content),
+        credentials: 'include'
       })
       if (!res.ok) throw new Error(`Failed to update page content: ${res.status} ${res.statusText}`)
 
@@ -63,7 +64,7 @@ const useContentAPI = () => {
       const base = process.env.NEXT_PUBLIC_API_BASE
       if (!base) throw new Error('API base URL is not defined')
 
-      const res = await fetch(`${base}/api/admin/settings/images`)
+      const res = await fetch(`${base}/api/admin/settings/images`, { credentials: 'include' })
       if (!res.ok) throw new Error(`Failed to fetch image settings: ${res.status} ${res.statusText}`)
 
       return await res.json()
@@ -81,7 +82,8 @@ const useContentAPI = () => {
       const res = await fetch(`${base}/api/admin/settings/images`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settings)
+        body: JSON.stringify(settings),
+        credentials: 'include'
       })
       if (!res.ok) throw new Error(`Failed to update image settings: ${res.status} ${res.statusText}`)
 
@@ -97,7 +99,7 @@ const useContentAPI = () => {
       const base = process.env.NEXT_PUBLIC_API_BASE
       if (!base) throw new Error('API base URL is not defined')
 
-      const res = await fetch(`${base}/api/admin/settings/layout`)
+      const res = await fetch(`${base}/api/admin/settings/layout`, { credentials: 'include' })
       if (!res.ok) throw new Error(`Failed to fetch layout settings: ${res.status} ${res.statusText}`)
 
       return await res.json()
@@ -115,7 +117,8 @@ const useContentAPI = () => {
       const res = await fetch(`${base}/api/admin/settings/layout`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settings)
+        body: JSON.stringify(settings),
+        credentials: 'include'
       })
       if (!res.ok) throw new Error(`Failed to update layout settings: ${res.status} ${res.statusText}`)
 
@@ -160,7 +163,7 @@ export async function getAllPages() {
   const base = process.env.NEXT_PUBLIC_API_BASE
   if (!base) throw new Error('API base URL is not defined')
 
-  const res = await fetch(`${base}/api/admin/pages`)
+  const res = await fetch(`${base}/api/admin/pages`, { credentials: 'include' })
   if (!res.ok) throw new Error(`Failed to fetch pages: ${res.status} ${res.statusText}`)
   return res.json()
 }
@@ -170,7 +173,7 @@ export async function getPageContent(pageId) {
   const base = process.env.NEXT_PUBLIC_API_BASE
   if (!base) throw new Error('API base URL is not defined')
 
-  const res = await fetch(`${base}/api/admin/pages/${pageId}`)
+  const res = await fetch(`${base}/api/admin/pages/${pageId}`, { credentials: 'include' })
   if (!res.ok) throw new Error(`Failed to fetch page content: ${res.status} ${res.statusText}`)
   return res.json()
 }
@@ -183,7 +186,8 @@ export async function updatePageContent(pageId, content) {
   const res = await fetch(`${base}/api/admin/pages/${pageId}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(content)
+    body: JSON.stringify(content),
+    credentials: 'include'
   })
   if (!res.ok) throw new Error(`Failed to update page content: ${res.status} ${res.statusText}`)
   return res.json()
@@ -193,7 +197,7 @@ export async function getImageSettings() {
   const base = process.env.NEXT_PUBLIC_API_BASE
   if (!base) throw new Error('API base URL is not defined')
 
-  const res = await fetch(`${base}/api/admin/settings/images`)
+  const res = await fetch(`${base}/api/admin/settings/images`, { credentials: 'include' })
   if (!res.ok) throw new Error(`Failed to fetch image settings: ${res.status} ${res.statusText}`)
   return res.json()
 }
@@ -205,7 +209,8 @@ export async function updateImageSettings(settings) {
   const res = await fetch(`${base}/api/admin/settings/images`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(settings)
+    body: JSON.stringify(settings),
+    credentials: 'include'
   })
   if (!res.ok) throw new Error(`Failed to update image settings: ${res.status} ${res.statusText}`)
   return res.json()
@@ -215,7 +220,7 @@ export async function getLayoutSettings() {
   const base = process.env.NEXT_PUBLIC_API_BASE
   if (!base) throw new Error('API base URL is not defined')
 
-  const res = await fetch(`${base}/api/admin/settings/layout`)
+  const res = await fetch(`${base}/api/admin/settings/layout`, { credentials: 'include' })
   if (!res.ok) throw new Error(`Failed to fetch layout settings: ${res.status} ${res.statusText}`)
   return res.json()
 }
@@ -227,7 +232,8 @@ export async function updateLayoutSettings(settings) {
   const res = await fetch(`${base}/api/admin/settings/layout`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(settings)
+    body: JSON.stringify(settings),
+    credentials: 'include'
   })
   if (!res.ok) throw new Error(`Failed to update layout settings: ${res.status} ${res.statusText}`)
   return res.json()


### PR DESCRIPTION
## Summary
Implements #37: Add `credentials: 'include'` to admin API fetch calls

- Added `credentials: 'include'` to all 14 admin fetch calls in `lib/contentApi.js` (7 hook + 7 standalone)
- Added `credentials: 'include'` to 5 admin/user-specific fetch calls in `lib/api.js` (`getUserOrders`, `getPhotoImageSettings`, `updatePhotoImageSettings` — hook + standalone)
- Public endpoints (`getCategories`, `getPhotos`, `getPublicPageContent`, etc.) intentionally left unchanged

## Why
Cross-origin requests (frontend:3000 → backend:4000) silently drop session cookies without `credentials: 'include'`. Once the backend enforces BetterAuth session authentication on admin routes, all admin API calls would fail.

## Backend Coordination
**Important:** The backend ([gregory-taylor-backend](https://github.com/frankbria/gregory-taylor-backend)) must be updated with CORS configuration before deploying this:
- `Access-Control-Allow-Credentials: true`
- `Access-Control-Allow-Origin: <specific frontend origin>` (NOT wildcard `*`)

## Test Plan
- [x] All 20 fetch assertion tests updated to expect `credentials: 'include'`
- [x] 83/83 targeted tests passing
- [x] 668/668 full suite tests passing
- [x] Linting clean

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API requests to properly include credentials with authentication-protected endpoints

* **Tests**
  * Updated test suite across multiple API modules to validate credential inclusion in HTTP requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->