### PR TITLE
fix: replace absolute positioning on cart icon with flexbox layout

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -17,20 +17,19 @@ function Header() {
 
       {/* Navigation */}
       <nav className="bg-black text-white uppercase text-sm tracking-wide py-2">
-        <div className="max-w-5xl mx-auto flex justify-center items-center gap-6 relative">
-          <Link href="/" className="hover:underline">Home</Link>
-          <Link href="/gallery" className="hover:underline">Gallery</Link>
-          <Link href="/about" className="hover:underline">About</Link>
-          <Link href="/contact" className="hover:underline">Contact</Link>
-          <Link href="/orders" className="hover:underline">My Orders</Link>
-
-          {/* Cart icon positioned on the right edge */}
-          <div className="absolute right-60 flex items-center space-x-1">
-            <Link href="/cart" className="flex items-center hover:text-blue-400 transition">
-              <FaShoppingCart />
-              <span className="ml-1">{cartCount}</span>
-            </Link>
+        <div className="max-w-5xl mx-auto px-4 flex items-center gap-6">
+          <div className="flex flex-1 justify-center items-center gap-6">
+            <Link href="/" className="hover:underline">Home</Link>
+            <Link href="/gallery" className="hover:underline">Gallery</Link>
+            <Link href="/about" className="hover:underline">About</Link>
+            <Link href="/contact" className="hover:underline">Contact</Link>
+            <Link href="/orders" className="hover:underline">My Orders</Link>
           </div>
+
+          <Link href="/cart" className="flex items-center hover:text-blue-400 transition">
+            <FaShoppingCart />
+            <span className="ml-1">{cartCount}</span>
+          </Link>
         </div>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- Removes `absolute right-60` positioning from cart icon that broke on mobile screens
- Uses nested flexbox: nav links centered via `flex-1 justify-center`, cart icon in normal document flow on the right
- Adds `px-4` horizontal padding to prevent edge-to-edge layout on small screens

## Before → After
**Before:** Cart icon used `absolute right-60` — a fixed pixel offset that moved off-screen or overlapped nav links on mobile.

**After:** Cart icon sits in the flex flow, always visible at the right edge regardless of screen width.

## Test plan
- [x] `npm test` — 51 suites, 742 tests passing
- [x] `npm run lint` — no errors
- [x] `npm run build` — succeeds
- [ ] Visual: verify cart icon at 320px, 375px, 768px, 1024px, 1920px
- [ ] Visual: verify cart count badge stays aligned with icon
- [ ] Visual: no horizontal overflow on mobile

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized header navigation layout with centered main navigation links and cart link repositioned to the right side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->